### PR TITLE
Add @p-j/eapi-util-fetcheventhandler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: 15
       - run: yarn --pure-lockfile
+      - run: yarn lerna exec yarn -- -- --pure-lockfile
       - run: yarn test
         env:
           CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 15
       - run: yarn --pure-lockfile
-      - run: yarn lerna exec yarn -- -- --pure-lockfile
+      - run: yarn build
       - run: yarn test
         env:
           CI: true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ While EAPI packages are meant to work together with [`p-j/worker-eapi-template`]
 | [`@p-j/eapi-middleware-errorhandler`](./packages/eapi-middleware-errorHandler) | Catch exceptions, forward them or print them | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-errorhandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-errorhandler) |
 | [`@p-j/eapi-middleware-redirect`](./packages/eapi-middleware-redirect)         | Redirect, Rewrite or Proxy Requests          | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-redirect?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-redirect)         |
 | [`@p-j/eapi-util-applymiddlewares`](./packages/eapi-util-applyMiddlewares)     | A utility to combine multiple middlewares    | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-applymiddlewares?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-applymiddlewares)     |
+| [`@p-j/eapi-util-fetcheventhandler`](./packages/eapi-util-fetchEventHandler)   | Apply global middlewares & Match Routes      | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-fetchEventHandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-fetchEventHandler)   |
 | [`@p-j/eapi-types`](./packages/eapi-types)                                     | Common TypeScript typings for EAPI projects  | [![version](https://img.shields.io/npm/v/@p-j/eapi-types?style=flat-square)](https://npmjs.com/package/@p-j/eapi-types)                                     |
 
 ## Usage
@@ -102,7 +103,6 @@ While this middleware is intended to be used with [`@p-j/worker-eapi-template`](
 
 ```ts
 import { withCache } from '@p-j/eapi-middleware-cache'
-import { RequestContext } from '@p-j/eapi-types'
 
 function requestHandler({ event, request, params }: RequestContext): Response {
   return new Response('Hello World!')
@@ -127,6 +127,7 @@ addEventListener('fetch', (event) => {
 - [`@p-j/eapi-middleware-errorhandler`](./packages/eapi-middleware-errorHandler)
 - [`@p-j/eapi-middleware-redirect`](./packages/eapi-middleware-redirect)
 - [`@p-j/eapi-util-applymiddlewares`](./packages/eapi-util-applyMiddlewares)
+- [`@p-j/eapi-util-fetcheventhandler`](./packages/eapi-util-fetchEventHandler)
 
 ## Types
 

--- a/packages/eapi-middleware-cache/package.json
+++ b/packages/eapi-middleware-cache/package.json
@@ -21,7 +21,7 @@
   "types": "dist/withCache.d.ts",
   "devDependencies": {
     "@cloudflare/workers-types": "^2.0.0",
-    "@p-j/eapi-types": "^1.0.0"
+    "@p-j/eapi-types": "^1.0.0-alpha.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/eapi-middleware-cors/package.json
+++ b/packages/eapi-middleware-cors/package.json
@@ -21,7 +21,7 @@
   "types": "dist/withCors.d.ts",
   "devDependencies": {
     "@cloudflare/workers-types": "^2.0.0",
-    "@p-j/eapi-types": "^1.0.0"
+    "@p-j/eapi-types": "^1.0.0-alpha.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/eapi-middleware-errorhandler/package.json
+++ b/packages/eapi-middleware-errorhandler/package.json
@@ -4,7 +4,7 @@
   "description": "An Error Handler middleware to work within an EAPI app. Check worker-eapi-template for context.",
   "license": "MIT",
   "author": "Jérémie Parker <github@jeremie-parker.com>",
-  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-middleware-errorHandler",
+  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-middleware-errorhandler",
   "keywords": [
     "eapi",
     "workers",
@@ -22,7 +22,7 @@
   "types": "dist/withErrorHandler.d.ts",
   "devDependencies": {
     "@cloudflare/workers-types": "^2.0.0",
-    "@p-j/eapi-types": "^1.0.0"
+    "@p-j/eapi-types": "^1.0.0-alpha.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/eapi-middleware-redirect/package.json
+++ b/packages/eapi-middleware-redirect/package.json
@@ -21,7 +21,7 @@
   "types": "dist/withRedirect.d.ts",
   "devDependencies": {
     "@cloudflare/workers-types": "^2.0.0",
-    "@p-j/eapi-types": "^1.0.0"
+    "@p-j/eapi-types": "^1.0.0-alpha.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/eapi-util-applymiddlewares/package.json
+++ b/packages/eapi-util-applymiddlewares/package.json
@@ -4,7 +4,7 @@
   "description": "EAPI utility function that make the whole middleware stack work.",
   "license": "MIT",
   "author": "Jérémie Parker <github@jeremie-parker.com>",
-  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-util-applyMiddlewares",
+  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-util-applymiddlewares",
   "keywords": [
     "eapi",
     "workers",

--- a/packages/eapi-util-fetcheventhandler/LICENSE
+++ b/packages/eapi-util-fetcheventhandler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Jérémie Parker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eapi-util-fetcheventhandler/README.md
+++ b/packages/eapi-util-fetcheventhandler/README.md
@@ -1,0 +1,50 @@
+# `@p-j/eapi-util-fetchEventHandler`
+
+> This package provide a Fetch Event Handler factory that can be used in a multi-router setup.
+>
+> It's especially useful if you combine originless routes with traditional routes on the same project
+>
+> It also facilitate the application of "global" middlwares to all your routes.
+
+## Usage
+
+```ts
+import { fetchEventHandler } from '@p-j/eapi-util-fetcheventhandler'
+import { withErrorHandler } from '@p-j/eapi-middleware-errorhandler'
+
+const requestHandler: RequestHandler = (context) => new Response('Hello World')
+const matcher: RouteMatcher = (event) => { handler: requestHandler, param: {} }
+
+const eventHandler = fetchEventHandler({
+  matcher,
+  originless: true,
+  middlewares: [withErrorHandler()]
+})
+
+addEventListener('fetch', (event) => event.respondWith(fetchEventHandler(event)))
+```
+
+## Example with `tiny-request-router`
+
+```ts
+import { fetchEventHandler } from '@p-j/eapi-util-fetcheventhandler'
+import { withErrorHandler } from '@p-j/eapi-middleware-errorhandler'
+
+const requestHandler: RequestHandler = (context: RequestContext) => new Response('Hello World')
+
+export const router = new Router()
+router.all('/', requestHandler)
+
+const matcher: RouteMatcher = (event: FetchEvent) => {
+  const { pathname } = new URL(event.request.url)
+  return router.match(event.request.method as Method, pathname)
+}
+
+export const fetchEventHandler = eventHandlerFactory({
+  matcher,
+  originless: true,
+  middlewares: [withErrorHandler()],
+})
+
+addEventListener('fetch', (event) => event.respondWith(fetchEventHandler(event)))
+```

--- a/packages/eapi-util-fetcheventhandler/package.json
+++ b/packages/eapi-util-fetcheventhandler/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@p-j/eapi-util-fetcheventhandler",
+  "version": "1.0.0",
+  "description": "EAPI utility function that make the whole middleware stack work.",
+  "license": "MIT",
+  "author": "Jérémie Parker <github@jeremie-parker.com>",
+  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-util-fetchEventHandler",
+  "keywords": [
+    "eapi",
+    "workers",
+    "cloudflare",
+    "cloudflare-workers",
+    "middleware",
+    "utility"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/p-j/eapi.git"
+  },
+  "main": "dist/applyMiddlewares.js",
+  "types": "dist/applyMiddlewares.d.ts",
+  "devDependencies": {
+    "@cloudflare/workers-types": "^2.0.0",
+    "@p-j/eapi-types": "^1.0.0"
+  },
+  "dependencies": {
+    "@p-j/eapi-util-applymiddlewares": "^1.0.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "setupFiles": [
+      "../../jest.setup.ts"
+    ]
+  },
+  "scripts": {
+    "build": "rimraf ./dist && tsc",
+    "test": "jest"
+  }
+}

--- a/packages/eapi-util-fetcheventhandler/package.json
+++ b/packages/eapi-util-fetcheventhandler/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@p-j/eapi-util-fetcheventhandler",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "EAPI utility function that make the whole middleware stack work.",
   "license": "MIT",
   "author": "Jérémie Parker <github@jeremie-parker.com>",
-  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-util-fetchEventHandler",
+  "homepage": "https://github.com/p-j/eapi/tree/main/packages/eapi-util-fetcheventhandler",
   "keywords": [
     "eapi",
     "workers",
@@ -21,10 +21,10 @@
   "types": "dist/applyMiddlewares.d.ts",
   "devDependencies": {
     "@cloudflare/workers-types": "^2.0.0",
-    "@p-j/eapi-types": "^1.0.0"
+    "@p-j/eapi-types": "^1.0.0-alpha.0"
   },
   "dependencies": {
-    "@p-j/eapi-util-applymiddlewares": "^1.0.0"
+    "@p-j/eapi-util-applymiddlewares": "^1.0.0-alpha.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/eapi-util-fetcheventhandler/src/fetchEventHandler.test.ts
+++ b/packages/eapi-util-fetcheventhandler/src/fetchEventHandler.test.ts
@@ -1,0 +1,83 @@
+import { fetchEventHandler } from './fetchEventHandler'
+import fetchMock from 'jest-fetch-mock'
+
+describe('fetchEventHandler', () => {
+  const requestHandler = () => new Response('OK', { status: 200 })
+
+  const successfullMatcher = () => ({
+    handler: requestHandler,
+    params: {},
+  })
+
+  const faillingMatcher = () => null
+
+  const middlewares = [
+    function middleware(requestHandler: RequestHandler): RequestHandler {
+      return async ({}: RequestContext) => {
+        const originalResponse = await requestHandler({} as RequestContext)
+        const response = new Response(originalResponse.body, originalResponse)
+        response.headers.append('X-Middleware-Applied', 'true')
+        return response
+      }
+    },
+  ]
+
+  it('handle a fetch event with a configured matcher', async () => {
+    const eventHandler = fetchEventHandler({
+      matcher: successfullMatcher,
+      originless: true,
+      middlewares,
+    })
+
+    const response = await eventHandler({} as FetchEvent)
+
+    expect(await response.text()).toBe('OK')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Middleware-Applied')).toBe('true')
+  })
+
+  it('returns a 404 if the matcher returns null and originless is true', async () => {
+    const eventHandler = fetchEventHandler({
+      matcher: faillingMatcher,
+      originless: true,
+      middlewares,
+    })
+
+    const response = await eventHandler({} as FetchEvent)
+
+    expect(await response.text()).toBe('Not Found')
+    expect(response.status).toBe(404)
+    expect(response.headers.get('X-Middleware-Applied')).toBe(null)
+  })
+
+  describe('with fetch mock', () => {
+    beforeAll(() => {
+      fetchMock.enableMocks()
+    })
+
+    afterAll(() => {
+      fetchMock.disableMocks()
+    })
+
+    it('let the request pass through if an origin is defined and the matcher returns null', async () => {
+      const eventHandler = fetchEventHandler({
+        matcher: faillingMatcher,
+        originless: false,
+        middlewares,
+      })
+
+      const request = new Request('https://example.com')
+      const event = new FetchEvent('fetch', { request })
+      // for some reason the request isn't available on the FetchEvent, so we force it here
+      Object.assign(event, { request })
+
+      fetchMock.mockResponseOnce('Hello World')
+
+      const response = await eventHandler(event)
+
+      expect(await response.text()).toBe('Hello World')
+      expect(response.status).toBe(200)
+      expect(response.headers.get('X-Middleware-Applied')).toBe(null)
+    })
+  })
+})

--- a/packages/eapi-util-fetcheventhandler/src/fetchEventHandler.ts
+++ b/packages/eapi-util-fetcheventhandler/src/fetchEventHandler.ts
@@ -1,0 +1,46 @@
+import { applyMiddlewares } from '@p-j/eapi-util-applymiddlewares'
+
+export interface EventHandlerFactoryOptions {
+  matcher: RouteMatcher
+  originless?: boolean
+  middlewares?: Middleware[]
+}
+
+/**
+ * Fetch Event Handler Factory
+ * This reusable factory can be used in a multi-router setup.
+ * It's especially useful if you combine originless routes with traditional routes on the same project
+ * @param options
+ * @param options.matcher a function that given a FetchEvent returns the corresponding RequestHandler & Params.
+ * @param options.originless whether or not the eventHandler has an origin to default to. Defaults to false.
+ * @param options.middlewares an array of Middleware to be applied to every RequestHandler
+ * @returns the eventHandler for the given configuration
+ */
+export function fetchEventHandler({
+  matcher,
+  originless = false,
+  middlewares = [],
+}: EventHandlerFactoryOptions): FetchEventHandler {
+  /**
+   * Event Handler
+   * Passes the RequestContext to the RequestHandler if a route is matched
+   * continue to the origin otherwise, unless it's an originless setup
+   * @param event the original FetchEvent received by the worker
+   * @returns the final promise of response to be sent to the client
+   */
+  return async function _fetchEventHandler(event: FetchEvent) {
+    const match = matcher(event)
+
+    const requestContext = {
+      event,
+      request: event.request,
+      params: (match && match.params) || {},
+    }
+
+    return match // apply all middlwares to build the final request handler and pass it the request context
+      ? applyMiddlewares(match.handler, ...middlewares)(requestContext)
+      : originless // if no match, respond with a 404 in case of an oringless worker, call the origin otherwise
+      ? new Response('Not Found', { status: 404 })
+      : fetch(event.request)
+  }
+}

--- a/packages/eapi-util-fetcheventhandler/tsconfig.json
+++ b/packages/eapi-util-fetcheventhandler/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
- Provide a factory allowing for setting up global middleware
- Router agnostic
- Plays well with tiny-request-router

Requires a first release of [`@p-j/eapi-util-applymiddlewares`](https://github.com/p-j/eapi/tree/main/packages/eapi-util-applymiddlewares)