### PR TITLE
Add changelog links & prepare 1.0.0 for more packages

### DIFF
--- a/.changeset/friendly-elephants-dream.md
+++ b/.changeset/friendly-elephants-dream.md
@@ -1,0 +1,8 @@
+---
+'@p-j/eapi-middleware-cache': major
+'@p-j/eapi-util-applymiddlewares': major
+'@p-j/eapi-middleware-errorhandler': major
+'@p-j/eapi-types': major
+---
+
+Initial release of the packages: @p-j/eapi-middleware-cache, @p-j/eapi-util-applymiddlewares, @p-j/eapi-middleware-errorhandler, @p-j/eapi-types

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ It's a collection of common building blocks you need to build a scalable and com
 
 While EAPI packages are meant to work together with [`p-j/worker-eapi-template`](https://github.com/p-j/worker-eapi-template), you can also use them as standalone functions as [demonstrated below](https://github.com/p-j/eapi#standalone).
 
-| Package                                                                        | Description                                  | Version                                                                                                                                                     |
-| ------------------------------------------------------------------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@p-j/eapi-middleware-cache`](./packages/eapi-middleware-cache)               | Configure browser & CDN cache                | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-cache?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-cache)               |
-| [`@p-j/eapi-middleware-cors`](./packages/eapi-middleware-cors)                 | Validate Origin & Apply CORS Headers         | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-cors?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-cors)                 |
-| [`@p-j/eapi-middleware-errorhandler`](./packages/eapi-middleware-errorhandler) | Catch exceptions, forward them or print them | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-errorhandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-errorhandler) |
-| [`@p-j/eapi-middleware-redirect`](./packages/eapi-middleware-redirect)         | Redirect, Rewrite or Proxy Requests          | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-redirect?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-redirect)         |
-| [`@p-j/eapi-util-applymiddlewares`](./packages/eapi-util-applymiddlewares)     | A utility to combine multiple middlewares    | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-applymiddlewares?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-applymiddlewares)     |
-| [`@p-j/eapi-util-fetcheventhandler`](./packages/eapi-util-fetcheventhandler)   | Apply global middlewares & Match Routes      | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-fetcheventhandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-fetcheventhandler)   |
-| [`@p-j/eapi-types`](./packages/eapi-types)                                     | Common TypeScript typings for EAPI projects  | [![version](https://img.shields.io/npm/v/@p-j/eapi-types?style=flat-square)](https://npmjs.com/package/@p-j/eapi-types)                                     |
+| Package                                                                        | Description                                  | Version                                                                                                                                                     | Changelog                                                                                                                                                  |
+| ------------------------------------------------------------------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@p-j/eapi-middleware-cache`](./packages/eapi-middleware-cache)               | Configure browser & CDN cache                | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-cache?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-cache)               | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-middleware-cache)        |
+| [`@p-j/eapi-middleware-cors`](./packages/eapi-middleware-cors)                 | Validate Origin & Apply CORS Headers         | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-cors?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-cors)                 | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-middleware-cors)         |
+| [`@p-j/eapi-middleware-errorhandler`](./packages/eapi-middleware-errorhandler) | Catch exceptions, forward them or print them | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-errorhandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-errorhandler) | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-middleware-errorhandler) |
+| [`@p-j/eapi-middleware-redirect`](./packages/eapi-middleware-redirect)         | Redirect, Rewrite or Proxy Requests          | [![version](https://img.shields.io/npm/v/@p-j/eapi-middleware-redirect?style=flat-square)](https://npmjs.com/package/@p-j/eapi-middleware-redirect)         | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-middleware-redirect)     |
+| [`@p-j/eapi-util-applymiddlewares`](./packages/eapi-util-applymiddlewares)     | A utility to combine multiple middlewares    | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-applymiddlewares?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-applymiddlewares)     | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-util-applymiddlewares)   |
+| [`@p-j/eapi-util-fetcheventhandler`](./packages/eapi-util-fetcheventhandler)   | Apply global middlewares & Match Routes      | [![version](https://img.shields.io/npm/v/@p-j/eapi-util-fetcheventhandler?style=flat-square)](https://npmjs.com/package/@p-j/eapi-util-fetcheventhandler)   | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-util-fetcheventhandler)  |
+| [`@p-j/eapi-types`](./packages/eapi-types)                                     | Common TypeScript typings for EAPI projects  | [![version](https://img.shields.io/npm/v/@p-j/eapi-types?style=flat-square)](https://npmjs.com/package/@p-j/eapi-types)                                     | [![changelog](https://img.shields.io/badge/changelogs.xyz-browse-brightgreen?style=flat-square)](https://changelogs.xyz/@p-j/eapi-types)                   |
 
 ## Usage
 
@@ -40,10 +40,11 @@ This example is already setup in [`@p-j/worker-eapi-template`](https://github.co
 // src/router.ts
 
 import { Router } from 'tiny-request-router'
-import { TTL_30MINUTES } from './helpers/konstants'
 import { withCache } from '@p-j/eapi-middleware-cache'
 import { withErrorHandler } from '@p-j/eapi-middleware-errorhandler'
 import { applyMiddlewares } from '@p-j/eapi-util-applymiddlewares'
+
+const TTL_30MINUTES = 60 * 30
 
 function requestHandler({ event, request, params }: RequestContext): Response {
   return new Response('Hello World!')
@@ -114,6 +115,7 @@ const cacheForOneHour = withCache({ cacheControl: 'public; max-age=3600' })
 const finalRequestHandler = cacheForOneHour(requestHandler)
 
 addEventListener('fetch', (event) => {
+  // The only constraints is that the RequestHandler needs to take in a RequestContext
   const requestContext = { event, request: event.request, params: {} }
   // use the enhanced request handler to build the response
   event.respondWith(finaleRequestHandler(requestContext))
@@ -154,3 +156,7 @@ While nothing prevents you from using all the eapi-\* packages in a Javascript p
 #### Making them discoverable
 
 Feel free to use the eapi-\* naming if your middleware is compatible, and the eapi tag on github & npm to ensure discoverability.
+
+### Contributing to this repository
+
+Pull Request are welcome to add more middlewares, utility or request handler to this collection.

--- a/packages/eapi-middleware-cache/README.md
+++ b/packages/eapi-middleware-cache/README.md
@@ -1,4 +1,4 @@
-# `eapi-middleware-cache`
+# `@p-j/eapi-middleware-cache`
 
 > A middleware to configure cache behavior on a per route or request basis
 

--- a/packages/eapi-util-applymiddlewares/README.md
+++ b/packages/eapi-util-applymiddlewares/README.md
@@ -2,6 +2,16 @@
 
 > Apply a list of middlwares to a given request handler, returning an enhanced request handler
 
+## Installation
+
+- From the NPM registry
+
+```sh
+npm install @p-j/eapi-util-applymiddlewares
+# or
+yarn add @p-j/eapi-util-applymiddlewares
+```
+
 ## Usage
 
 ```ts

--- a/packages/eapi-util-fetcheventhandler/README.md
+++ b/packages/eapi-util-fetcheventhandler/README.md
@@ -6,6 +6,16 @@
 >
 > It also facilitate the application of "global" middlwares to all your routes.
 
+## Installation
+
+- From the NPM registry
+
+```sh
+npm install @p-j/eapi-util-fetcheventhandler
+# or
+yarn add @p-j/eapi-util-fetcheventhandler
+```
+
 ## Usage
 
 ```ts


### PR DESCRIPTION
Release of 1.0.0 for
- @p-j/eapi-middleware-cache
- @p-j/eapi-util-applymiddlewares
- @p-j/eapi-middleware-errorhandler
- @p-j/eapi-types

and small documentation edits