### PR TITLE
refacto(cors): use manageHeaders for CORS headers

### DIFF
--- a/.changeset/cyan-chefs-shout.md
+++ b/.changeset/cyan-chefs-shout.md
@@ -1,0 +1,11 @@
+---
+'@p-j/eapi-middleware-cors': minor
+'@p-j/eapi-middleware-headers': minor
+---
+
+- @p-j/eapi-middleware-headers
+  - export utility functions to handle header values
+  - ignore header with empty values
+- @p-j/eapi-middleware-cors
+  - use utility functions to handle CORS headers
+  - update tests accordingly

--- a/packages/eapi-middleware-cors/package.json
+++ b/packages/eapi-middleware-cors/package.json
@@ -35,5 +35,8 @@
   "scripts": {
     "build": "rimraf ./dist && tsc",
     "test": "jest"
+  },
+  "dependencies": {
+    "@p-j/eapi-middleware-headers": "^1.0.0"
   }
 }

--- a/packages/eapi-middleware-cors/src/withCors.test.ts
+++ b/packages/eapi-middleware-cors/src/withCors.test.ts
@@ -1,8 +1,9 @@
 import { cors, withCors } from './withCors'
+import { serializeHeaderValues } from '@p-j/eapi-middleware-headers'
 
 const defaultAccessControlAllowOrigin = '*'
-const defaultAccessControlAllowHeaders = ['Origin', 'Content-Type', 'Accept', 'Authorization'].join(', ')
-const defaultAccessControlAllowMethods = ['GET', 'OPTIONS', 'HEAD'].join(', ')
+const defaultAccessControlAllowHeaders = serializeHeaderValues(['Origin', 'Content-Type', 'Accept', 'Authorization'])
+const defaultAccessControlAllowMethods = serializeHeaderValues(['GET', 'OPTIONS', 'HEAD'])
 const defaultAccessControlMaxAge = '3600'
 
 const accessControlAllowHeaders = ['Accept', 'Authorization', 'Cache-Control', 'Content-Type', 'Origin', 'User-Agent']
@@ -34,8 +35,8 @@ describe('Cors', () => {
         response: new Response(undefined, { status: 200 }),
         accessControlExposeHeaders: ['*', 'Authorization'],
       })
-      expect(response.headers.get('Access-Control-Expose-Headers')).toBe('Content-Length, Authorization')
-      expect(response2.headers.get('Access-Control-Expose-Headers')).toBe('*, Authorization')
+      expect(response.headers.get('Access-Control-Expose-Headers')).toBe('Content-Length,Authorization')
+      expect(response2.headers.get('Access-Control-Expose-Headers')).toBe('*,Authorization')
     })
 
     it('should set cors headers on a given response', () => {
@@ -47,8 +48,12 @@ describe('Cors', () => {
         accessControlMaxAge,
       })
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://tata.com')
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe(accessControlAllowHeaders.join(', '))
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(accessControlAllowMethods.join(', '))
+      expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
+        serializeHeaderValues(accessControlAllowHeaders),
+      )
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
+        serializeHeaderValues(accessControlAllowMethods),
+      )
       expect(response.headers.get('Access-Control-Max-Age')).toBe(String(accessControlMaxAge))
       expect(response.headers.get('Vary')).toBe('Origin')
     })
@@ -105,8 +110,12 @@ describe('Cors', () => {
       const response = await requestHandler({ event, request, params: {} })
 
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://tata.com')
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe(accessControlAllowHeaders.join(', '))
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(accessControlAllowMethods.join(', '))
+      expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
+        serializeHeaderValues(accessControlAllowHeaders),
+      )
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
+        serializeHeaderValues(accessControlAllowMethods),
+      )
       expect(response.headers.get('Access-Control-Max-Age')).toBe(String(accessControlMaxAge))
       expect(response.headers.get('Vary')).toBe('Origin')
     })

--- a/packages/eapi-middleware-headers/src/withHeaders.ts
+++ b/packages/eapi-middleware-headers/src/withHeaders.ts
@@ -79,22 +79,24 @@ export function manageHeaders({
       const values = parseHeaderValues(value)
       const originalValues = parseHeaderValues(subject.headers.get(header) || '')
 
-      switch (existing) {
-        case 'combine':
-          // Ensure unique values while combining
-          subject.headers.set(header, serializeHeaderValues(originalValues, values))
+      if (values.length) {
+        switch (existing) {
+          case 'combine':
+            // Ensure unique values while combining
+            subject.headers.set(header, serializeHeaderValues(originalValues, values))
 
-          break
-        case 'override':
-          // Ensure unique values while overriding
-          subject.headers.set(header, serializeHeaderValues(values))
-          break
-        case 'skip':
-          if (!originalValues.length) {
+            break
+          case 'override':
+            // Ensure unique values while overriding
             subject.headers.set(header, serializeHeaderValues(values))
-          }
-        default:
-          break
+            break
+          case 'skip':
+            if (!originalValues.length) {
+              subject.headers.set(header, serializeHeaderValues(values))
+            }
+          default:
+            break
+        }
       }
     })
   }
@@ -104,13 +106,13 @@ export function manageHeaders({
   return subject
 }
 
-function parseHeaderValues(valueString: string): string[] {
+export function parseHeaderValues(valueString: string): string[] {
   return valueString
     .split(',')
     .map((value) => value.trim())
     .filter((v) => !!v)
 }
 
-function serializeHeaderValues(...values: string[][]): string {
+export function serializeHeaderValues(...values: string[][]): string {
   return [...new Set(values.flat())].filter((v) => !!v).join(',')
 }


### PR DESCRIPTION
- @p-j/eapi-middleware-headers
  - export utility functions to handle header values
  - ignore header with empty values
- @p-j/eapi-middleware-cors
  - use utility functions to handle CORS headers
  - update tests accordingly